### PR TITLE
add -r 1 toggle option

### DIFF
--- a/fb-rotate.c
+++ b/fb-rotate.c
@@ -24,7 +24,9 @@ usage(void)
     fprintf(stderr, "usage: %s -l\n"
                     "       %s -i\n"
                     "       %s -d <display ID> -m\n"
-                    "       %s -d <display ID> -r <0|90|180|270>\n",
+                    "       %s -d <display ID> -r <0|90|180|270|1>\n"
+	            "\n"
+	            "-r 1 signfies 90 if currently not rotated; otherwise 0 (i.e. toggle)\n",
                     PROGNAME, PROGNAME, PROGNAME, PROGNAME);
     exit(1);
 }
@@ -174,6 +176,7 @@ main(int argc, char **argv)
 {
     int  i;
     long angle = 0;
+    long currentRotation = 0;
    
     io_service_t      service;
     CGDisplayErr      dErr;
@@ -206,6 +209,15 @@ main(int argc, char **argv)
    
     if (targetDisplay == 0)
         usage();
+
+    if (angle == 1) {
+        currentRotation = CGDisplayRotation (targetDisplay);
+        if (currentRotation == 0) {
+	  angle = 90;
+	} else {
+          angle = 0;
+	}
+    }
    
     options = angle2options(angle);
    


### PR DESCRIPTION
A rotation of "1" is now allowed, which acts as a toggle between 0 and 90; if rotation is 0, set rotation to 90; if it is anything else, set to 0.  Allows for using the same command to alternate between the two most common monitor rotations.

Branch mscuthbert/fb-rotate latest has all of the pull requests merged into one.
